### PR TITLE
Smarter PTH POSIX TLS variables

### DIFF
--- a/include/qemu/thread.h
+++ b/include/qemu/thread.h
@@ -82,11 +82,13 @@ typedef struct QemuThread QemuThread;
 	#define PTH(NAME) w->NAME
 	#define PTH_X(NAME, ORIG) w->NAME
 	#define PTH_YIELD pth_yield(NULL);
+	#define PTH_TLS_GET(NAME) pth_get_wrapper()->NAME
 #else
 	#define PTH(NAME) NAME
 	#define PTH_UPDATE_CONTEXT
 	#define PTH_X(NAME, ORIG) ORIG
 	#define PTH_YIELD
+    #define PTH_TLS_GET(NAME) assert(false);
 #endif
 
 #define QEMU_THREAD_JOINABLE 0

--- a/util/qemu-thread-pth-internal.c
+++ b/util/qemu-thread-pth-internal.c
@@ -42,8 +42,6 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //  DO-NOT-REMOVE end-copyright-block
-#ifdef CONFIG_PTH
-
 #include "qemu/thread-pth-internal.h"
 
 /*
@@ -1033,5 +1031,3 @@ int pthpthread_abort(pth_t thread)
         return errno;
     return OK;
 }
-
-#endif //  CONFIG_PTH

--- a/util/qemu-thread-pth.c
+++ b/util/qemu-thread-pth.c
@@ -42,8 +42,6 @@
 // LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //  DO-NOT-REMOVE end-copyright-block
-#ifdef CONFIG_PTH
-
 #include "qemu/osdep.h"
 #include "qemu/thread.h"
 #include "qemu/atomic.h"
@@ -613,6 +611,3 @@ pth_wrapper* pth_get_wrapper(void){
 
     assert(false && "pth: thread was none added to pth thread list! did you use function attributes? if yes, they are not supported.");
 }
-
-
-#endif //  CONFIG_PTH


### PR DESCRIPTION
In order to support POSIX TLS with PTH, we did a method that wrapped all the variables unique to the thread (TLS) in a PTH structure.

But the way this was done was very aggressive and hard to maintain. Here, as a proof of concept, I propose a method that is still implicit in to the user showing that TLS `__thread` variable declaration have been changed with a `PTH_TLS_GET`, without interfering in the rest of the code with calls to `PTH_UPDATE_CONTEXT` and `PTH(variable)`.

The only downside of this solution is that instead of calling a single time `PTH_UPDATE_CONTEXT` in the entry of a function that has a `__thread` variable, we call it multiple times on every variable access. 