### PR TITLE
Base GitLab CI tests moved to GitHub Actions

### DIFF
--- a/.github/workflows/qemu-jobs.yml
+++ b/.github/workflows/qemu-jobs.yml
@@ -152,18 +152,20 @@ jobs:
              else
                ./configure --enable-werror --disable-docs --disable-containers $CONFIGURE_ARGS ;
              fi || { cd build && cat config.log meson-logs/meson-log.txt && exit 1; }
-      - name: Run meson configure LD_JOBS (conditional)
-        if: ${{ matrix.ld_jobs }}
+      - name: Run meson configure LD_JOBS
         run: if test -n "$LD_JOBS";
              then
                meson configure . -Dbackend_max_links="$LD_JOBS" ;
              fi || exit 1;
       - name: Make 
         run: make -j$(expr $(nproc) + 1)
-      - name: Run extra checks tests (conditional)
-        if: ${{ env.MAKE_CHECK_ARGS }}
-        run: make -j$(expr $(nproc) + 1) $MAKE_CHECK_ARGS ;
-        # NOTE: We tar the artifact before saving to keep file permissions
+      - name: Run check-build
+        run: make -j$(expr $(nproc) + 1) check-build ;
+      - name: Run extra checks tests
+        run: |
+          if [ ! -z "$MAKE_CHECK_ARGS" ]; then
+            ASAN_OPTIONS=detect_leaks=0 make -j$(expr $(nproc) + 1) $MAKE_CHECK_ARGS;
+          fi
       - name: Tar artifact (build folder) (conditional)
         if: ${{ matrix.upload-build == 'true'}}
         run: tar -cf build.tar build

--- a/.github/workflows/qemu-jobs.yml
+++ b/.github/workflows/qemu-jobs.yml
@@ -18,8 +18,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - # NOTE: --enable-fdt=system --enable-slirp=system was removed
-            build-name: Build for Ubuntu 20.04 + check # build-system-ubuntu
+          - build-name: Build for Ubuntu 20.04 + check # build-system-ubuntu # NOTE: --enable-fdt=system --enable-slirp=system was removed compared to upstream QEMU job def
             targets: aarch64-softmmu
             make-check-args: check
           - build-name: Build for user-mode + check-tcg # build-user
@@ -30,26 +29,19 @@ jobs:
             targets: aarch64-softmmu
             configure-args: --disable-tools --enable-debug
             make-check-args: check-tcg
-#          - build-name: build-user-plugins
-#            targets: aarch64-linux-user
-#            configure-args: --disable-tools --disable-system --enable-plugins --enable-debug-tcg
-#            make-check-args: check-tcg
           - build-name: Build for system-mode with plugins enabled + check-tcg # build-some-softmmu-plugins
             targets: aarch64-softmmu
             configure-args: --disable-tools --disable-user --enable-plugins --enable-debug-tcg
             make-check-args: check-tcg
           - build-name: Build for system-mode with clang + check-tcg, check-qtest + UBSAN, ASAN # clang-system
             targets: aarch64-softmmu
-            configure-args: --cc=clang --cxx=clang++
-              --extra-cflags=-fsanitize=undefined --extra-cflags=-fno-sanitize-recover=undefined
+            configure-args: --cc=clang --cxx=clang++ --enable-sanitizers --extra-cflags=-fno-sanitize-recover=undefined
             make-check-args: check-qtest check-tcg
           - build-name: Build for user-mode with clang + check-tcg, check-unit + UBSAN, ASAN # clang-user
             targets: aarch64-linux-user
-            configure-args: --cc=clang --cxx=clang++ --disable-system
-              --extra-cflags=-fsanitize=undefined --extra-cflags=-fsanitize=address --extra-cflags=-fno-sanitize-recover=undefined
+            configure-args: --cc=clang --cxx=clang++ --disable-system --enable-sanitizers --extra-cflags=-fno-sanitize-recover=undefined
             make-check-args: check-unit check-tcg
-          - # NOTE: removed --disable-pie because it results in compilation errors on ubuntu
-            build-name: Build with all features disabled + check-qtest # build-disabled
+          - build-name: Build with all features disabled + check-qtest # build-disabled # NOTE: removed --disable-pie because it results in compilation errors on ubuntu
             targets: aarch64-softmmu
             make-check-args: check-qtest SPEED=slow
             configure-args: 

--- a/.github/workflows/qemu-jobs.yml
+++ b/.github/workflows/qemu-jobs.yml
@@ -160,8 +160,6 @@ jobs:
              fi || exit 1;
       - name: Make 
         run: make -j$(expr $(nproc) + 1)
-      - name: Run check-build
-        run: make -j$(expr $(nproc) + 1) check-build ;
       - name: Run extra checks tests (conditional)
         if: ${{ env.MAKE_CHECK_ARGS }}
         run: make -j$(expr $(nproc) + 1) $MAKE_CHECK_ARGS ;

--- a/.github/workflows/qemu-jobs.yml
+++ b/.github/workflows/qemu-jobs.yml
@@ -41,7 +41,7 @@ jobs:
           - build-name: Build for system-mode with clang + check-tcg, check-qtest + UBSAN, ASAN # clang-system
             targets: aarch64-softmmu
             configure-args: --cc=clang --cxx=clang++
-              --extra-cflags=-fsanitize=undefined --extra-cflags=-fsanitize=address  --extra-cflags=-fno-sanitize-recover=undefined
+              --extra-cflags=-fsanitize=undefined --extra-cflags=-fno-sanitize-recover=undefined
             make-check-args: check-qtest check-tcg
           - build-name: Build for user-mode with clang + check-tcg, check-unit + UBSAN, ASAN # clang-user
             targets: aarch64-linux-user

--- a/.github/workflows/qemu-jobs.yml
+++ b/.github/workflows/qemu-jobs.yml
@@ -38,16 +38,16 @@ jobs:
             targets: aarch64-softmmu
             configure-args: --disable-tools --disable-user --enable-plugins --enable-debug-tcg
             make-check-args: check-tcg
-          - build-name: Build using clang + check-tcg, check-qtest # clang-system
+          - build-name: Build for system-mode with clang + check-tcg, check-qtest + UBSAN, ASAN # clang-system
             targets: aarch64-softmmu
             configure-args: --cc=clang --cxx=clang++
-              --extra-cflags=-fsanitize=undefined --extra-cflags=-fno-sanitize-recover=undefined
+              --extra-cflags=-fsanitize=undefined --extra-cflags=-fsanitize=address  --extra-cflags=-fno-sanitize-recover=undefined
             make-check-args: check-qtest check-tcg
-#          - build-name: clang-user
-#            targets: aarch64-linux-user
-#            configure-args: --cc=clang --cxx=clang++ --disable-system
-#              --extra-cflags=-fsanitize=undefined --extra-cflags=-fno-sanitize-recover=undefined
-#            make-check-args: check-unit check-tcg
+          - build-name: Build for user-mode with clang + check-tcg, check-unit + UBSAN, ASAN # clang-user
+            targets: aarch64-linux-user
+            configure-args: --cc=clang --cxx=clang++ --disable-system
+              --extra-cflags=-fsanitize=undefined --extra-cflags=-fsanitize=address --extra-cflags=-fno-sanitize-recover=undefined
+            make-check-args: check-unit check-tcg
           - # NOTE: removed --disable-pie because it results in compilation errors on ubuntu
             build-name: Build with all features disabled + check-qtest # build-disabled
             targets: aarch64-softmmu

--- a/.github/workflows/qemu-jobs.yml
+++ b/.github/workflows/qemu-jobs.yml
@@ -48,11 +48,6 @@ jobs:
 #            configure-args: --cc=clang --cxx=clang++ --disable-system
 #              --extra-cflags=-fsanitize=undefined --extra-cflags=-fno-sanitize-recover=undefined
 #            make-check-args: check-unit check-tcg
-          - build-name: Build with TCG interpreter, lauches boot and cdrom tests # build-tci
-            targets: aarch64-softmmu
-            configure-args: --enable-tcg-interpreter
-            make-check-args: tests/qtest/boot-serial-test tests/qtest/cdrom-test
-            launch-test-args: tests/qtest/boot-serial-test tests/qtest/cdrom-test
           - # NOTE: removed --disable-pie because it results in compilation errors on ubuntu
             build-name: Build with all features disabled + check-qtest # build-disabled
             targets: aarch64-softmmu
@@ -132,7 +127,6 @@ jobs:
       CONFIGURE_ARGS: ${{ matrix.configure-args }}
       MAKE_CHECK_ARGS: ${{ matrix.make-check-args }}
       LD_JOBS: ${{ matrix.ld_jobs }}
-      LAUNCH_TEST_ARGS: ${{ matrix.launch-test-args }}
     steps:
       - name: Checkout directory
         uses: actions/checkout@v2
@@ -172,15 +166,6 @@ jobs:
         if: ${{ env.MAKE_CHECK_ARGS }}
         run: make -j$(expr $(nproc) + 1) $MAKE_CHECK_ARGS ;
         # NOTE: We tar the artifact before saving to keep file permissions
-      - name: Run individual tests (conditional)
-        if: ${{ matrix.launch-test-args }}
-        run: for tg in $TARGETS ; do
-               export QTEST_QEMU_BINARY="./qemu-system-${tg}" ;
-               for test in $LAUNCH_TEST_ARGS ; do
-                  ./${test} || exit 1 ;
-               done
-             done
-        working-directory: build
       - name: Tar artifact (build folder) (conditional)
         if: ${{ matrix.upload-build == 'true'}}
         run: tar -cf build.tar build

--- a/.github/workflows/qemu-jobs.yml
+++ b/.github/workflows/qemu-jobs.yml
@@ -1,0 +1,193 @@
+name: Build and check tests for QFlex enabled and base QEMU
+
+on: 
+  push:
+    branches:
+      - master
+      - dev
+  pull_request:
+    branches:
+      - master
+      - dev
+  workflow_dispatch:
+
+jobs:
+  build_and_check_job_definition: # native_build_job_definition:
+    runs-on: ubuntu-latest
+    name: Configure, build and check QEMU # native_build_job_definition
+    strategy:
+      matrix:
+        include:
+          - # NOTE: --enable-fdt=system --enable-slirp=system was removed
+            build-name: Build for Ubuntu 20.04 + check # build-system-ubuntu
+            targets: aarch64-softmmu
+            make-check-args: check
+          - build-name: Build for user-mode + check-tcg # build-user
+            targets: aarch64-linux-user
+            configure-args: --disable-tools --disable-system
+            make-check-args: check-tcg
+          - build-name: Build for system-mode + check-tcg # build-some-softmmu
+            targets: aarch64-softmmu
+            configure-args: --disable-tools --enable-debug
+            make-check-args: check-tcg
+#          - build-name: build-user-plugins
+#            targets: aarch64-linux-user
+#            configure-args: --disable-tools --disable-system --enable-plugins --enable-debug-tcg
+#            make-check-args: check-tcg
+          - build-name: Build for system-mode with plugins enabled + check-tcg # build-some-softmmu-plugins
+            targets: aarch64-softmmu
+            configure-args: --disable-tools --disable-user --enable-plugins --enable-debug-tcg
+            make-check-args: check-tcg
+          - build-name: Build using clang + check-tcg, check-qtest # clang-system
+            targets: aarch64-softmmu
+            configure-args: --cc=clang --cxx=clang++
+              --extra-cflags=-fsanitize=undefined --extra-cflags=-fno-sanitize-recover=undefined
+            make-check-args: check-qtest check-tcg
+#          - build-name: clang-user
+#            targets: aarch64-linux-user
+#            configure-args: --cc=clang --cxx=clang++ --disable-system
+#              --extra-cflags=-fsanitize=undefined --extra-cflags=-fno-sanitize-recover=undefined
+#            make-check-args: check-unit check-tcg
+          - build-name: Build with TCG interpreter, lauches boot and cdrom tests # build-tci
+            targets: aarch64-softmmu
+            configure-args: --enable-tcg-interpreter
+            make-check-args: tests/qtest/boot-serial-test tests/qtest/cdrom-test
+            launch-test-args: tests/qtest/boot-serial-test tests/qtest/cdrom-test
+          - # NOTE: removed --disable-pie because it results in compilation errors on ubuntu
+            build-name: Build with all features disabled + check-qtest # build-disabled
+            targets: aarch64-softmmu
+            make-check-args: check-qtest SPEED=slow
+            configure-args: 
+              --disable-attr
+              --disable-auth-pam
+              --disable-avx2
+              --disable-bochs
+              --disable-brlapi
+              --disable-bzip2
+              --disable-cap-ng
+              --disable-capstone
+              --disable-cloop
+              --disable-coroutine-pool
+              --disable-curl
+              --disable-curses
+              --disable-dmg
+              --disable-docs
+              --disable-gcrypt
+              --disable-glusterfs
+              --disable-gnutls
+              --disable-gtk
+              --disable-guest-agent
+              --disable-iconv
+              --disable-keyring
+              --disable-kvm
+              --disable-libiscsi
+              --disable-libpmem
+              --disable-libssh
+              --disable-libudev
+              --disable-libusb
+              --disable-libxml2
+              --disable-linux-aio
+              --disable-live-block-migration
+              --disable-lzo
+              --disable-malloc-trim
+              --disable-mpath
+              --disable-nettle
+              --disable-numa
+              --disable-opengl
+              --disable-parallels
+              --disable-qcow1
+              --disable-qed
+              --disable-qom-cast-debug
+              --disable-rbd
+              --disable-rdma
+              --disable-replication
+              --disable-sdl
+              --disable-seccomp
+              --disable-sheepdog
+              --disable-slirp
+              --disable-smartcard
+              --disable-snappy
+              --disable-sparse
+              --disable-spice
+              --disable-strip
+              --disable-tpm
+              --disable-usb-redir
+              --disable-vdi
+              --disable-vhost-crypto
+              --disable-vhost-net
+              --disable-vhost-scsi
+              --disable-vhost-kernel
+              --disable-vhost-user
+              --disable-vhost-vdpa
+              --disable-vhost-vsock
+              --disable-virglrenderer
+              --disable-vnc
+              --disable-vte
+              --disable-vvfat
+              --disable-xen
+              --disable-zstd
+    timeout-minutes: 90
+    env: 
+      TARGETS: ${{ matrix.targets }}
+      CONFIGURE_ARGS: ${{ matrix.configure-args }}
+      MAKE_CHECK_ARGS: ${{ matrix.make-check-args }}
+      LD_JOBS: ${{ matrix.ld_jobs }}
+      LAUNCH_TEST_ARGS: ${{ matrix.launch-test-args }}
+    steps:
+      - name: Checkout directory
+        uses: actions/checkout@v2
+## Alternatively to executing the `install-deps.sh` script on every job, one 
+## could run the tests in a docker image with all the dependencies preinstalled.
+#      - name: Fetch Docker image from QEMU
+#        uses: docker://registry.gitlab.com/qemu-project/qemu/qemu/ubuntu2004
+      - name: Install depedencies
+        run: bash scripts/qflex/install-deps.sh
+      - # NOTE: For some reason, slirp submodule is not fetched correctly in GitHub Actions
+        name: Build and install slirp (conditional)
+        if: contains(matrix.configure-args, 'enable-slirp')
+        run: |
+          git submodule update --init --recursive slirp 
+          git submodule update --remote slirp
+          cd slirp 
+          meson build 
+          sudo ninja -C build install
+      - name: Configure
+        run: if test -n "$TARGETS"; 
+             then
+               ./configure --enable-werror --disable-docs --disable-containers $CONFIGURE_ARGS --target-list="$TARGETS" ;
+             else
+               ./configure --enable-werror --disable-docs --disable-containers $CONFIGURE_ARGS ;
+             fi || { cd build && cat config.log meson-logs/meson-log.txt && exit 1; }
+      - name: Run meson configure LD_JOBS (conditional)
+        if: ${{ matrix.ld_jobs }}
+        run: if test -n "$LD_JOBS";
+             then
+               meson configure . -Dbackend_max_links="$LD_JOBS" ;
+             fi || exit 1;
+      - name: Make 
+        run: make -j$(expr $(nproc) + 1)
+      - name: Run check-build
+        run: make -j$(expr $(nproc) + 1) check-build ;
+      - name: Run extra checks tests (conditional)
+        if: ${{ env.MAKE_CHECK_ARGS }}
+        run: make -j$(expr $(nproc) + 1) $MAKE_CHECK_ARGS ;
+        # NOTE: We tar the artifact before saving to keep file permissions
+      - name: Run individual tests (conditional)
+        if: ${{ matrix.launch-test-args }}
+        run: for tg in $TARGETS ; do
+               export QTEST_QEMU_BINARY="./qemu-system-${tg}" ;
+               for test in $LAUNCH_TEST_ARGS ; do
+                  ./${test} || exit 1 ;
+               done
+             done
+        working-directory: build
+      - name: Tar artifact (build folder) (conditional)
+        if: ${{ matrix.upload-build == 'true'}}
+        run: tar -cf build.tar build
+      - name: Save and upload artifact (conditional)
+        uses: actions/upload-artifact@v2
+        if: ${{ matrix.upload-build == 'true'}}
+        with:
+          retention-days: 2
+          name: ${{ matrix.build-name }}
+          path: build.tar

--- a/scripts/qflex/install-deps.sh
+++ b/scripts/qflex/install-deps.sh
@@ -38,6 +38,7 @@ sudo apt-get update && \
         libpthread-stubs0-dev \
         gcc-aarch64-linux-gnu \
         libc6-dev-arm64-cross \
+        gdb-multiarch \
         libiscsi-dev
 
 # Install meson as root

--- a/scripts/qflex/install-deps.sh
+++ b/scripts/qflex/install-deps.sh
@@ -36,6 +36,8 @@ sudo apt-get update && \
         python3-venv \
         python3-pip \
         libpthread-stubs0-dev \
+        gcc-aarch64-linux-gnu \
+        libc6-dev-arm64-cross \
         libiscsi-dev
 
 # Install meson as root

--- a/scripts/qflex/install-deps.sh
+++ b/scripts/qflex/install-deps.sh
@@ -1,0 +1,56 @@
+## Step 1: Install dependencies, see https://wiki.qemu.org/Hosts/Linux
+
+sudo apt-get update && \
+    DEBIAN_FRONTEND=noninteractive sudo apt-get -y install --no-install-recommends \
+        git \
+        ninja-build \
+        libglib2.0-dev \
+        libfdt-dev \
+        libpixman-1-dev \
+        zlib1g-dev \
+        libaio-dev \
+        libbluetooth-dev \
+        libbrlapi-dev \
+        libbz2-dev \
+        libcap-dev \
+        libcap-ng-dev \
+        libcurl4-gnutls-dev \
+        libgtk-3-dev \
+        libibverbs-dev \
+        libjpeg8-dev \
+        libncurses5-dev \
+        libnuma-dev \
+        librbd-dev \
+        librdmacm-dev \
+        libsasl2-dev \
+        libseccomp-dev \
+        libsnappy-dev \
+        libssh2-1-dev \
+        libnfs-dev \
+        python3-sphinx \
+        python3-yaml \
+        clang \
+        gcc \
+        pkg-config \
+        git-core \
+        python3-venv \
+        python3-pip \
+        libpthread-stubs0-dev \
+        libiscsi-dev
+
+# Install meson as root
+# sudo pip uninstall -y meson && sudo pip install meson
+
+#        libsdl1.2-dev \
+
+#        libvde-dev \
+#        libvdeplug-dev \
+#        libvte-2.91-dev \
+#        libxen-dev \
+#        liblzo2-dev \
+
+# sudo dpkg -l $PACKAGES | sort > /packages.txt
+
+# Apply patch https://reviews.llvm.org/D75820
+# This is required for TSan in clang-10 to compile with QEMU.
+sudo sed -i 's/^const/static const/g' /usr/lib/llvm-10/lib/clang/10.0.0/include/sanitizer/tsan_interface.h


### PR DESCRIPTION
This pull request contains a port of core QEMU CI infrastructure from GitLab CI to GitHub Actions.

Given that we do not require all the test and deployment features of GitLab CI, we have not ported  a significant part of the tests, such as those concerning deployment containers, documentation, and support for niche platforms.

Contrary to the GitLab CI approach of using functions, and the equivalent method called actions in GitHub Actions, we use a matrix to launch the test with different parameters. The zip file contained in this commit offers an alternative method closer to the original CI infra for organizing the jobs.

All these tests only test for the target architecture aarch64 and are ran on a Ubuntu 20.04 host.

An explanation of what QEMU's CI infrastructure looks like can be seen [here](https://github.com/parsa-epfl/qemu/files/6817591/QEMU-ci-infra.txt), and some of the rationale behind which tests we decided to support can be found [here](https://github.com/parsa-epfl/qemu/files/6817592/QEMU-ci-rationale.txt).

We are missing one category of testing with this infra: `check-acceptance`. This is because GitLab CI acceptance test uses many features of GitLab itself (artefacts, caches, before script, functions, etc), and it is more tricky to bring to GitHub Actions.

