### PR TITLE
feat: Allow icount mode import checkpoints created without icount

### DIFF
--- a/accel/tcg/icount-common.c
+++ b/accel/tcg/icount-common.c
@@ -125,7 +125,7 @@ static int64_t icount_get_locked(void)
 {
     int64_t icount = icount_get_raw_locked();
     return qatomic_read_i64(&timers_state.qemu_icount_bias) +
-        icount_to_ns(icount);
+        icount_to_ns(icount) + timers_state.virtual_clock_snapshot;
 }
 
 int64_t icount_get_raw(void)

--- a/include/sysemu/cpu-timers-internal.h
+++ b/include/sysemu/cpu-timers-internal.h
@@ -52,6 +52,9 @@ typedef struct TimersState {
     int64_t vm_clock_warp_start;
     int64_t cpu_clock_offset;
 
+    /* Add by Cyan. the vm_clock from the recent snapshot */
+    int64_t virtual_clock_snapshot;
+
     /* Only written by TCG thread */
     int64_t qemu_icount;
 

--- a/target/arm/helper.c
+++ b/target/arm/helper.c
@@ -934,7 +934,8 @@ static int64_t cycles_ns_per(uint64_t cycles)
 
 static bool instructions_supported(CPUARMState *env)
 {
-    return icount_enabled() == 1; /* Precise instruction counting */
+    // return icount_enabled() == 1; /* Precise instruction counting */
+    return false;
 }
 
 static uint64_t instructions_get_count(CPUARMState *env)


### PR DESCRIPTION
This PR includes:
- Check bypassing for icount-related states
- Time conversion from the non-icount checkpoint (stored in the `timers_state.cpu_clock_offset`) to the icount time calculation